### PR TITLE
added some optimisation for less memory\DB usage

### DIFF
--- a/src/components/MetaTagBehavior.php
+++ b/src/components/MetaTagBehavior.php
@@ -18,6 +18,10 @@ use yii\validators\SafeValidator;
  */
 class MetaTagBehavior extends Behavior
 {
+    /**
+     * @var bool|array
+     */
+    protected static $_tagList = false;
 
     /**
      * Array of meta tag data list
@@ -175,9 +179,13 @@ class MetaTagBehavior extends Behavior
      */
     protected function getTagList()
     {
-        return MetaTag::find()
-            ->where('is_active = :is_active', [':is_active' => 1])
-            ->orderBy(['position' => SORT_DESC])
-            ->all();
+        if (static::$_tagList === false) {
+            static::$_tagList = MetaTag::find()
+                ->where('is_active = :is_active', [':is_active' => 1])
+                ->orderBy(['position' => SORT_DESC])
+                ->all();
+        }
+
+        return static::$_tagList;
     }
 }

--- a/src/components/MetaTagBehavior.php
+++ b/src/components/MetaTagBehavior.php
@@ -21,7 +21,7 @@ class MetaTagBehavior extends Behavior
     /**
      * @var bool|array
      */
-    protected static $_tagList = false;
+    protected static $_tagList = [];
 
     /**
      * Array of meta tag data list
@@ -179,9 +179,9 @@ class MetaTagBehavior extends Behavior
      */
     protected function getTagList()
     {
-        if (static::$_tagList === false) {
+        if (!static::$_tagList) {
             static::$_tagList = MetaTag::find()
-                ->where('is_active = :is_active', [':is_active' => 1])
+                ->where(['is_active' => 1])
                 ->orderBy(['position' => SORT_DESC])
                 ->all();
         }


### PR DESCRIPTION
removed multiple calls of getTagList() method, now it stores in static variable because columns for SEO are same for all project models, there is no reason to collect them more than once